### PR TITLE
change bgd colors of address with ping

### DIFF
--- a/addressing.css
+++ b/addressing.css
@@ -39,11 +39,11 @@
 }
 
 .plugin_addressing_ping_on {
-   background-color: #A2BB8D;
+   background-color: #8CB8D8;
 }
 
 .plugin_addressing_ping_off {
-   background-color: #CF9B9B;
+   background-color: #FFFF6B;
 }
 
 


### PR DESCRIPTION
Hi,
just small changes on colors background when ping is used. The actual colors are to close to be readable.
now:
![capture d ecran de 2017-05-23 16-04-16](https://cloud.githubusercontent.com/assets/5741421/26358033/8813b1cc-3fd1-11e7-891a-5789a7a57d23.png)
