### PR TITLE
fix(xml): use direct URL for logo without params

### DIFF
--- a/addressing.xml
+++ b/addressing.xml
@@ -3,7 +3,7 @@
    <name>IP Report</name>
    <key>addressing</key>
    <state>stable</state>
-   <logo>https://github.com/pluginsGLPI/addressing/blob/master/addressing.png?raw=true</logo>
+   <logo>https://raw.githubusercontent.com/pluginsGLPI/addressing/master/addressing.png</logo>
    <description>
       <short>
           <fr><![CDATA[Rapport IP. Ce plugin vous permet créer un rapport IP afin de visualiser les adresses ip utilisées et libres sur un réseau donné. Génération de la liste des ip attribuées / libres / réservées / doublons. Personnalisation de l’affichage. Fonction ping adresses libres]]></fr>


### PR DESCRIPTION
For better marketplace compatibility (logo parsing).